### PR TITLE
fix: replace 'onNuxtReady' with 'globals.readyCallback'

### DIFF
--- a/templates/plugin.js
+++ b/templates/plugin.js
@@ -1,5 +1,5 @@
 export default function () {
-  window.onNuxtReady(() => {
+  window.<%= globals.readyCallback %>(() => {
     <% if (typeof options.url === 'string') { %>
       const link = document.createElement('link')
       link.rel = 'stylesheet'


### PR DESCRIPTION
This will enable usage of custom globalName property in nuxt.config