### PR TITLE
feat: add new `external` strategy for loading fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
-<h1 align="center">Nuxt Font Loader</h1>
+# Nuxt Font Loader
 
-<p align="center">Simple, modern and lightweight font loader for Nuxt projects.</p>
+Simple, modern and lightweight font loader for Nuxt projects.
 
 ## Features
 
 - Helps you to easily load fonts on your site
+- Supports _local_ and _external_ loading strategies
 - Follows modern methods and practices
 - Updated to Nuxt 3 Stable
 - TypeScript friendly
@@ -41,19 +42,19 @@ That's it! Start developing your app!
 
 ## Font Loading
 
-The new `nuxt-font-loader` module brings an updated font loading system to your project. All customizations are now defined in the main `nuxt.config.ts` file so it's easier to use.
+The new `nuxt-font-loader` module brings an updated font loading strategies to your project. All customizations are now defined in the main _nuxt.config.ts_ file so it's easier to use.
 
-At the moment, the `self-host` method is most recommended for handling fonts. In other words, it means that you can optimally load web fonts with performance, flexibility and privacy in mind.
+Also, the module supports popular methods for loading fonts on your site. You can use the `local` method, also called `self-host`, or you can load `external` font sources directly from third-party servers, such as Google, Typekit, etc.
+
+At the moment, the `self-host` _(i.e. local)_ method is most recommended for handling fonts. In other words, it means that you can optimally load web fonts with performance, flexibility and privacy in mind.
 
 Download all fonts and serve them from the same _domain_ as your deployment to avoid _third-party_ server requests and potential _privacy_ issues.
 
-## Usage
+## Local Strategy
 
-Place the previously downloaded fonts in the `public/fonts/` directory.
+Place the previously downloaded fonts in the `public/fonts/` directory and specify the path to the local font files.
 
-The `local` option accepts an array of objects so you can specify as many fonts as you like.
-
-Here are simple example:
+The module will automatically _preload_ sources so there is no need for additional customization.
 
 ```js
 // nuxt.config.ts
@@ -71,7 +72,7 @@ Here are simple example:
 }
 ```
 
-That's it! You can now use it in the _templates_ like this:
+You can now use it in the _templates_ like this:
 
 ```html
 <template>
@@ -107,9 +108,39 @@ That's it! You can now use it in the _templates_ like this:
 }
 ```
 
+## External Strategy
+
+To load fonts directly from third-party servers use `external` option.
+
+The module will automatically detect servers and _preload_ sources accordingly so you don't have to worry about it.
+
+```js
+// nuxt.config.ts
+
+{
+  fontLoader: {
+    external: [
+      {
+        src: 'https://fonts.googleapis.com/css2?family=Inter&display=swap',
+        family: 'Inter',
+        class: 'font-inter' // optional
+      }
+    ]
+  }
+}
+```
+
+You can now use it in the _templates_ like this:
+
+```html
+<template>
+  <h1 class="font-inter">Nuxt Font Loader</h1>
+</template>
+```
+
 ## Module Options
 
-The module has been completely rewritten so it's _typescript_ friendly.
+Nuxt Font Loader has been completely rewritten so it's _typescript_ friendly.
 
 It also improves the development experience with detailed descriptions, examples, and auto-hinted configuration right in the code editor.
 
@@ -120,7 +151,9 @@ It also improves the development experience with detailed descriptions, examples
 
 {
   fontLoader: {
-    local: []
+    local: [],
+    external: [],
+    logs: true
   }
 }
 ```
@@ -130,22 +163,22 @@ It also improves the development experience with detailed descriptions, examples
 - Type: `object[]`
 - Default: `[]`
 
-An array of objects that specifies local font sources. Each object is treated as a separate block of rules.
+An array of objects that specifies `local` font sources.
+
+Each object is treated as a separate block of rules.
 
 ```js
 // nuxt.config.ts
 
 {
-  fontLoader: {
-    local: [
-      {
-        src: '/fonts/AspektaVF.woff2',
-        family: 'Aspekta Variable',
-        weight: '100 900',
-        class: 'font-aspekta'
-      }
-    ]
-  }
+  local: [
+    {
+      src: '/fonts/AspektaVF.woff2',
+      family: 'Aspekta Variable',
+      weight: '100 900',
+      class: 'font-aspekta'
+    }
+  ]
 }
 ```
 
@@ -172,6 +205,27 @@ Defines the font family name.
 ```js
 {
   family: 'Family Name'
+}
+```
+
+### local.fallback
+
+- Type: `string`
+- Default: `undefined`
+
+Defines the font family fallback.
+
+```js
+{
+  fallback: 'sans-serif'
+}
+```
+
+Example above will generate the font fallback:
+
+```css
+.my-font {
+  font-family: 'family-name', sans-serif;
 }
 ```
 
@@ -277,6 +331,150 @@ So it can be used in templates:
 ```css
 h1 {
   font-family: var(--my-font);
+}
+```
+
+### external
+
+- Type: `object[]`
+- Default: `[]`
+
+An array of objects that specifies `external` font sources.
+
+It is also possible to specify static sources from the `public/` directory.
+
+Each object is treated as a separate block of rules.
+
+```js
+// nuxt.config.ts
+
+{
+  external: [
+    {
+      src: 'https://fonts.googleapis.com/css2?family=Inter&display=swap',
+      family: 'Inter',
+      class: 'Inter'
+    }
+  ]
+}
+```
+
+### external.src
+
+- Type: `string`
+- Required: `true`
+
+Specifies path to the external source.
+
+```js
+{
+  src: 'path-to-external-source'
+}
+```
+
+### external.family
+
+- Type: `string`
+- Default: `undefined`
+
+Defines the font family name.
+
+Use this in combination with the _class_ or _variable_ options.
+
+```js
+{
+  family: 'Family Name',
+  class: 'my-font'
+}
+```
+
+### external.fallback
+
+- Type: `string`
+- Default: `undefined`
+
+Defines the font family fallback.
+
+```js
+{
+  fallback: 'sans-serif'
+}
+```
+
+Example above will generate the font fallback:
+
+```css
+.my-font {
+  font-family: 'family-name', sans-serif;
+}
+```
+
+### external.class
+
+- Type: `string`
+- Default: `undefined`
+
+Defines the global css _class_ for the current source.
+
+```js
+{
+  class: 'my-font'
+}
+```
+
+Example above will generate global css class:
+
+```css
+.my-font {
+  font-family: 'family-name';
+}
+```
+
+So it can be used in templates:
+
+```html
+<h1 class="my-font">Font Loader</h1>
+```
+
+### external.variable
+
+- Type: `string`
+- Default: `undefined`
+
+Defines the global css _variable_ for the current source.
+
+```js
+{
+  variable: 'my-font'
+}
+```
+
+Example above will generate global css variable:
+
+```css
+:root {
+  --my-font: 'family-name';
+}
+```
+
+So it can be used in templates:
+
+```css
+h1 {
+  font-family: var(--my-font);
+}
+```
+
+### logs
+
+- Type: `boolean`
+- Default: `true`
+
+Manages all terminal logs.
+
+```js
+{
+  logs: true
 }
 ```
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,17 +1,9 @@
 import { defineNuxtModule } from '@nuxt/kit'
 import { log } from 'logzy'
-import { generateLocalHead } from './utils'
-import type { NuxtModule } from '@nuxt/schema'
+import { generateLocalHead, generateExternalHead } from './utils'
 import type { ModuleOptions } from './types'
 
-/**
- * Font Loader
- *
- * Simple, modern and lightweight font loader for Nuxt projects.
- *
- * @see [source](https://github.com/ivodolenc/nuxt-font-loader)
- */
-const FontLoader: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
+export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'nuxt-font-loader',
     configKey: 'fontLoader',
@@ -20,16 +12,20 @@ const FontLoader: NuxtModule<ModuleOptions> = defineNuxtModule<ModuleOptions>({
     }
   },
 
-  setup(options, nuxt) {
-    const { local } = options
+  defaults: {
+    logs: true
+  },
 
-    if (!local) {
+  setup(options, nuxt) {
+    const { local, external, logs } = options
+
+    if (!local && !external && logs) {
       const warnMessage = `> nuxt-font-loader — The module is enabled but not configured. Set new font sources via module options.`
       log(['magenta', 'bold'], warnMessage)
     }
 
     if (local) generateLocalHead(local, nuxt)
+
+    if (external) generateExternalHead(external, nuxt)
   }
 })
-
-export default FontLoader

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,26 @@ export interface LocalOptions {
    */
   family: string
   /**
+   * Defines the font family fallback.
+   *
+   * @example
+   *
+   * ```js
+   * {
+   *   fallback: 'sans-serif'
+   * }
+   * ```
+   *
+   * Example above will generate the font fallback:
+   *
+   * ```css
+   * .my-font { font-family: "family-name", sans-serif; }
+   * ```
+   *
+   * @default undefined
+   */
+  fallback?: string
+  /**
    * Defines the font weight.
    *
    * @example
@@ -101,28 +121,132 @@ export interface LocalOptions {
 }
 
 /**
+ * External Options.
+ *
+ * @since 2.1.0
+ */
+export interface ExternalOptions {
+  /**
+   * Specifies path to the external source.
+   *
+   * @note `required` option
+   */
+  src: string
+  /**
+   * Defines the font family name.
+   *
+   * Use this in combination with the `class` or `variable` options.
+   *
+   * @example
+   *
+   * ```js
+   * {
+   *   family: 'Family Name',
+   *   class: 'my-font'
+   * }
+   * ```
+   *
+   * @default undefined
+   */
+  family?: string
+  /**
+   * Defines the font family fallback.
+   *
+   * @example
+   *
+   * ```js
+   * {
+   *   fallback: 'sans-serif'
+   * }
+   * ```
+   *
+   * Example above will generate the font fallback:
+   *
+   * ```css
+   * .my-font { font-family: "family-name", sans-serif; }
+   * ```
+   *
+   * @default undefined
+   */
+  fallback?: string
+  /**
+   * Defines the global css `class` for the current source.
+   *
+   * @example
+   *
+   * ```js
+   * {
+   *   class: 'my-font'
+   * }
+   * ```
+   *
+   * Example above will generate global css class:
+   *
+   * ```css
+   * .my-font { font-family: "family-name"; }
+   * ```
+   *
+   * So it can be used in templates:
+   *
+   * ```html
+   * <h1 class="my-font">Font Loader</h1>
+   * ```
+   *
+   * @default undefined
+   */
+  class?: string
+  /**
+   * Defines the global css `variable` for the current source.
+   *
+   * @example
+   *
+   * ```js
+   * {
+   *   variable: 'my-font'
+   * }
+   * ```
+   *
+   * Example above will generate global css variable:
+   *
+   * ```css
+   * :root { --my-font: "family-name"; }
+   * ```
+   *
+   * So it can be used in templates:
+   *
+   * ```css
+   * h1 {
+   *   font-family: var(--my-font);
+   * }
+   * ```
+   *
+   * @default undefined
+   */
+  variable?: string
+}
+
+/**
  * Module Options.
  *
  * @since 2.0.0
  */
 export interface ModuleOptions {
   /**
-   * An array of objects that specifies local font sources. Each object is treated as a separate block of rules.
+   * An array of objects that specifies `local` font sources.
+   *
+   * Each object is treated as a separate block of rules.
    *
    * @example
    *
    * ```js
    * {
-   *   fontLoader: {
-   *     local: [
-   *       {
-   *         src: '/fonts/AspektaVF.woff2',
-   *         family: 'Aspekta Variable',
-   *         weight: '100 900',
-   *         class: 'font-aspekta'
-   *       }
-   *     ]
-   *   }
+   *   local: [
+   *     {
+   *       src: '/fonts/AspektaVF.woff2',
+   *       family: 'Aspekta Variable',
+   *       weight: '100 900'
+   *     }
+   *   ]
    * }
    * ```
    *
@@ -132,5 +256,50 @@ export interface ModuleOptions {
    *
    * @see [Aspekta Typeface](https://github.com/ivodolenc/aspekta)
    */
-  local: LocalOptions[]
+  local?: LocalOptions[]
+  /**
+   * An array of objects that specifies `external` font sources.
+   *
+   * It is also possible to specify static sources from the `public/` directory.
+   *
+   * Each object is treated as a separate block of rules.
+   *
+   * @example
+   *
+   * ```js
+   * {
+   *   external: [
+   *     {
+   *       src: 'path-to-external-source'
+   *     }
+   *   ]
+   * }
+   * ```
+   *
+   * @default []
+   *
+   * @since 2.1.0
+   */
+  external?: ExternalOptions[]
+  /**
+   * Manages all terminal logs.
+   *
+   * @default true
+   *
+   * @since 2.1.0
+   */
+  logs?: boolean
+}
+
+declare module '@nuxt/schema' {
+  interface NuxtConfig {
+    /**
+     * Nuxt Font Loader
+     *
+     * Simple, modern and lightweight font loader for Nuxt projects.
+     *
+     * @see [source](https://github.com/ivodolenc/nuxt-font-loader)
+     */
+    fontLoader?: ModuleOptions
+  }
 }

--- a/src/utils/generateHead.ts
+++ b/src/utils/generateHead.ts
@@ -1,16 +1,16 @@
 import type { Nuxt } from '@nuxt/schema'
-import type { LocalOptions } from '../types'
+import type { LocalOptions, ExternalOptions } from '../types'
 
 /**
- * Generates html tags inside `<head>` section for the local font sources.
+ * Generates html tags inside `<head>` section for the `local` font sources.
  *
  * @since 2.0.0
  */
 export const generateLocalHead = (local: LocalOptions[], nuxt: Nuxt) => {
   let fontFace = ''
   let classes = ''
-  let variables = ''
   let root = ''
+  let variables = ''
 
   for (const source of local) {
     const options = {
@@ -29,30 +29,95 @@ export const generateLocalHead = (local: LocalOptions[], nuxt: Nuxt) => {
       href: options.src
     })
 
+    const fontFallback = options.fallback ? `,${options.fallback}` : ''
     const fontFamily = `font-family:"${options.family}";`
     const fontWeight = `font-weight:${options.weight};`
     const fontDisplay = `font-display:${options.display};`
     const fontStyle = `font-style:${options.style};`
     const fontSrc = `src:url('${options.src}') format('${format}');`
 
-    if (options.class) {
-      classes += `.${options.class}{${fontFamily}}`
-    }
+    if (options.class)
+      classes += `.${options.class}{font-family:"${options.family}"${fontFallback};}`
 
-    if (options.variable) {
-      variables += `--${options.variable}:"${options.family}";`
-    }
+    if (options.variable)
+      variables += `--${options.variable}:"${options.family}"${fontFallback};`
 
     fontFace += `@font-face{${fontFamily}${fontWeight}${fontDisplay}${fontStyle}${fontSrc}}`
   }
 
-  if (variables) {
-    root += `:root{${variables}}`
-  }
+  if (variables) root += `:root{${variables}}`
 
   const styles = `${fontFace}${classes}${root}`
 
-  return nuxt.options.app.head.style?.push({
-    children: styles
-  })
+  return nuxt.options.app.head.style?.push({ children: styles })
+}
+
+/**
+ * Generates html tags inside `<head>` section for the `external` font sources.
+ *
+ * @since 2.1.0
+ */
+export const generateExternalHead = (
+  external: ExternalOptions[],
+  nuxt: Nuxt
+) => {
+  let google = false
+  let typekit = false
+  let classes = ''
+  let root = ''
+  let variables = ''
+
+  for (const source of external) {
+    const options = {
+      ...source
+    }
+
+    if (options.src.includes('google') && !google) {
+      google = true
+
+      nuxt.options.app.head.link?.push({
+        rel: 'preconnect',
+        href: 'https://fonts.googleapis.com'
+      })
+      nuxt.options.app.head.link?.push({
+        rel: 'preconnect',
+        crossorigin: 'anonymous',
+        href: 'https://fonts.gstatic.com'
+      })
+    }
+
+    if (options.src.includes('typekit') && !typekit) {
+      typekit = true
+
+      nuxt.options.app.head.link?.push({
+        rel: 'preconnect',
+        crossorigin: 'anonymous',
+        href: 'https://use.typekit.net'
+      })
+    }
+
+    nuxt.options.app.head.link?.push({
+      rel: 'preload',
+      as: 'style',
+      href: options.src
+    })
+    nuxt.options.app.head.link?.push({
+      rel: 'stylesheet',
+      href: options.src
+    })
+
+    const fontFallback = options.fallback ? `,${options.fallback}` : ''
+
+    if (options.class)
+      classes += `.${options.class}{font-family:"${options.family}"${fontFallback};}`
+
+    if (options.variable)
+      variables += `--${options.variable}:"${options.family}"${fontFallback};`
+  }
+
+  if (variables) root += `:root{${variables}}`
+
+  const styles = `${classes}${root}`
+
+  if (styles) return nuxt.options.app.head.style?.push({ children: styles })
 }


### PR DESCRIPTION
## Types of Changes

- [x] New feature 🚀
- [x] Documentation 📖

## Additional Details

- Updates documentation
- Improves types and examples
- Adds new `fontLoader.logs` option to manage all terminal logs
- Adds new `local.fallback` & `external.fallback` options to define the font family fallback.

## Request Description


### External Strategy

To load fonts directly from third-party servers use `external` option.

The module will automatically detect servers and _preload_ sources accordingly so you don't have to worry about it.

```js
// nuxt.config.ts

{
  fontLoader: {
    external: [
      {
        src: 'https://fonts.googleapis.com/css2?family=Inter&display=swap',
        family: 'Inter',
        class: 'font-inter' // optional
      }
    ]
  }
}
```