### PR TITLE
fix: add `#font-loader` alias for import composables

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Import the function where you need it.
 </template>
 
 <script setup lang="ts">
-  import { useLocalFont } from 'nuxt-font-loader/app'
+  import { useLocalFont } from '#font-loader'
 
   useLocalFont([
     {
@@ -175,7 +175,7 @@ Import the function where you need it.
 </template>
 
 <script setup lang="ts">
-  import { useExternalFont } from 'nuxt-font-loader/app'
+  import { useExternalFont } from '#font-loader'
 
   useExternalFont([
     {

--- a/package.json
+++ b/package.json
@@ -14,10 +14,6 @@
     ".": {
       "import": "./dist/module.mjs",
       "types": "./dist/types.d.ts"
-    },
-    "./app": {
-      "import": "./dist/runtime/composables/index.mjs",
-      "types": "./dist/runtime/composables/index.d.ts"
     }
   },
   "files": [

--- a/src/module.ts
+++ b/src/module.ts
@@ -21,12 +21,13 @@ export default defineNuxtModule<ModuleOptions>({
     const { local, external, autoImport } = options
     const head = nuxt.options.app.head
 
+    const { resolve } = createResolver(import.meta.url)
+    nuxt.options.build.transpile.push(resolve('./runtime'))
+
+    const composables = resolve('./runtime/composables')
+    nuxt.options.alias['#font-loader'] = composables
+
     if (autoImport) {
-      const { resolve } = createResolver(import.meta.url)
-      nuxt.options.build.transpile.push(resolve('./runtime'))
-
-      const composables = resolve('./runtime/composables')
-
       addImports([
         {
           name: 'useLocalFont',


### PR DESCRIPTION
## Types of Changes

<!-- At least one checkbox needs to be selected. -->

- [x] Bug fix 🐛

## Request Description

Fixes errors when importing `font composables`. 

Composables are now imported using the `#font-loader` alias.

```html
<!-- index.vue -->

<template>
  <h1 class="font-aspekta">Nuxt Font Loader</h1>
</template>

<script setup lang="ts">
  import { useLocalFont } from '#font-loader'

  useLocalFont([
    {
      src: '/fonts/Aspekta.woff2',
      family: 'Aspekta',
      class: 'font-aspekta' // optional
    }
  ])
</script>
```
