### PR TITLE
feat: add new `preload` and `unicode-range` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,43 @@ h1 {
 }
 ```
 
+### local.preload
+
+- Type: `boolean`
+- Default: `true`
+
+Specifies the _preload_ links.
+
+```js
+{
+  preload: true
+}
+```
+
+### local.unicode
+
+- Type: `string[]`
+- Default: `undefined`
+
+Defines a specific range of characters to be used from the font.
+
+```js
+{
+  preload: false, // Disables the preload link
+  display: 'swap', // or 'fallback', 'auto' ...
+  unicodeRange: ['U+26']
+}
+```
+
+Example above will generate:
+
+```css
+@font-face {
+  font-display: swap;
+  unicode-range: U+26;
+}
+```
+
 ### external
 
 - Type: `object[]`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "@nuxt/module-builder": "^0.2.1",
+        "@types/node": "^18.11.19",
         "@typescript-eslint/eslint-plugin": "^5.50.0",
         "@typescript-eslint/parser": "^5.50.0",
         "eslint": "^8.33.0",
@@ -1647,9 +1648,7 @@
       "version": "18.11.19",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.19.tgz",
       "integrity": "sha512-YUgMWAQBWLObABqrvx8qKO1enAvBUdjZOAWQ5grBAkp5LQv45jBvYKZ3oFS9iKRCQyFjqw6iuEa1vmFqtxYLZw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -5538,9 +5537,9 @@
       }
     },
     "node_modules/minipass": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.1.tgz",
-      "integrity": "sha512-V9esFpNbK0arbN3fm2sxDKqMYgIp7XtVdE4Esj+PE4Qaaxdg1wIw48ITQIOn1sc8xXSmUviVL3cyjMqPlrVkiA==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-4.0.2.tgz",
+      "integrity": "sha512-4Hbzei7ZyBp+1aw0874YWpKOubZd/jc53/XU+gkYry1QV+VvrbO8icLM5CUtm4F0hyXn85DXYKEMIS26gitD3A==",
       "dev": true,
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@nuxt/module-builder": "^0.2.1",
+    "@types/node": "^18.11.19",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.50.0",
     "eslint": "^8.33.0",

--- a/src/module.ts
+++ b/src/module.ts
@@ -45,15 +45,22 @@ export default defineNuxtModule<ModuleOptions>({
       const styles = `${fontFace}${classes}${root}`
 
       for (const font of local) {
-        const format = parseFormat(font.src)
+        const options = {
+          preload: true,
+          ...font
+        }
 
-        head.link?.push({
-          rel: 'preload',
-          as: 'font',
-          type: `font/${format}`,
-          crossorigin: 'anonymous',
-          href: font.src
-        })
+        if (options.preload) {
+          const format = parseFormat(font.src)
+
+          head.link?.push({
+            rel: 'preload',
+            as: 'font',
+            type: `font/${format}`,
+            crossorigin: 'anonymous',
+            href: font.src
+          })
+        }
       }
 
       head.style?.push({ children: styles })

--- a/src/runtime/composables/useLocalFont.ts
+++ b/src/runtime/composables/useLocalFont.ts
@@ -27,18 +27,25 @@ export const useLocalFont = (local: LocalOptions[]) => {
   const links: object[] = []
 
   for (const font of local) {
-    const format = parseFormat(font.src)
+    const options = {
+      preload: true,
+      ...font
+    }
 
-    links.push({
-      rel: 'preload',
-      as: 'font',
-      type: `font/${format}`,
-      crossorigin: 'anonymous',
-      href: font.src
-    })
+    if (options.preload) {
+      const format = parseFormat(font.src)
+
+      links.push({
+        rel: 'preload',
+        as: 'font',
+        type: `font/${format}`,
+        crossorigin: 'anonymous',
+        href: font.src
+      })
+    }
   }
 
-  useHead({ link: links })
+  if (links.length) useHead({ link: links })
 
   return useHead({ style: [{ children: styles }] })
 }

--- a/src/runtime/utils/generateStyles.ts
+++ b/src/runtime/utils/generateStyles.ts
@@ -19,7 +19,7 @@ export const generateStyles = (fonts: LocalOptions[] | ExternalOptions[]) => {
       style: 'normal',
       ...font
     }
-
+    const local = options as LocalOptions
     const srcFormat = parseFormat(options.src)
     let format = srcFormat
     if (srcFormat === 'ttf') format = 'truetype'
@@ -31,6 +31,8 @@ export const generateStyles = (fonts: LocalOptions[] | ExternalOptions[]) => {
     const fontDisplay = `font-display:${options.display};`
     const fontStyle = `font-style:${options.style};`
     const fontSrc = `src:url('${options.src}') format('${format}');`
+    let unicodes = ''
+    let fontUnicode = ''
 
     if (options.class)
       classes += `.${options.class}{font-family:"${options.family}"${fontFallback};}`
@@ -38,7 +40,12 @@ export const generateStyles = (fonts: LocalOptions[] | ExternalOptions[]) => {
     if (options.variable)
       variables += `--${options.variable}:"${options.family}"${fontFallback};`
 
-    fontFace += `@font-face{${fontFamily}${fontWeight}${fontDisplay}${fontStyle}${fontSrc}}`
+    if (local.unicode) {
+      for (const code of local.unicode) unicodes += `${code},`
+      fontUnicode = `unicode-range:${unicodes.replace(/,*$/, '')};`
+    }
+
+    fontFace += `@font-face{${fontFamily}${fontWeight}${fontDisplay}${fontStyle}${fontSrc}${fontUnicode}}`
   }
 
   if (variables) root += `:root{${variables}}`

--- a/src/types/local.ts
+++ b/src/types/local.ts
@@ -118,4 +118,32 @@ export interface LocalOptions {
    * @default undefined
    */
   variable?: string
+  /**
+   * Specifies the `preload` links.
+   *
+   * @default true
+   */
+  preload?: boolean
+  /**
+   * Defines a specific range of characters to be used from the font.
+   *
+   * @example
+   *
+   * ```js
+   * {
+   *   preload: false,
+   *   display: 'swap',
+   *   unicodeRange: ['U+26']
+   * }
+   * ```
+   *
+   * Example above will generate:
+   *
+   * ```css
+   * font-face { font-display: swap; unicode-range: U+26; }
+   * ```
+   *
+   * @default undefined
+   */
+  unicode?: string[]
 }


### PR DESCRIPTION
## Types of Changes

<!-- At least one checkbox needs to be selected. -->

- [x] New feature 🚀

## Additional Details

- [x] Documentation added 📑

## Request Description

Adds new [`preload`](https://github.com/ivodolenc/nuxt-font-loader#localpreload) and [`unicode-range`](https://github.com/ivodolenc/nuxt-font-loader#localunicode-range) options.

Closes #18 

