### PR TITLE
refactor: cleanup code to reduce final size

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,11 @@ Simple, modern and lightweight font loader for Nuxt.
   <tbody>
     <tr>
       <td>useLocalFont</td>
-      <td><code>~1.2kB</code> minified</td>
+      <td><code>~1.1kB</code> minified</td>
     </tr>
     <tr>
       <td>useExternalFont</td>
-      <td><code>~1.4kB</code> minified</td>
+      <td><code>~1.28kB</code> minified</td>
     </tr>
   </tbody>
 </table>

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,6 @@
+import type { ModuleOptions } from './types'
 import { defineNuxtModule, createResolver, addImports } from '@nuxt/kit'
 import { generateStyles, parseFormat } from './runtime/utils'
-import type { ModuleOptions } from './types'
 
 export * from './types'
 
@@ -29,14 +29,8 @@ export default defineNuxtModule<ModuleOptions>({
 
     if (autoImport) {
       addImports([
-        {
-          name: 'useLocalFont',
-          from: composables
-        },
-        {
-          name: 'useExternalFont',
-          from: composables
-        }
+        { name: 'useLocalFont', from: composables },
+        { name: 'useExternalFont', from: composables }
       ])
     }
 
@@ -51,15 +45,19 @@ export default defineNuxtModule<ModuleOptions>({
         }
 
         if (options.preload) {
-          const format = parseFormat(font.src)
+          const { src } = options
+          const format = parseFormat(src)
 
-          head.link?.push({
-            rel: 'preload',
-            as: 'font',
-            type: `font/${format}`,
-            crossorigin: 'anonymous',
-            href: font.src
-          })
+          // eslint-disable-next-line
+          if (!head.link?.some((v: any) => v.href === src)) {
+            head.link?.push({
+              rel: 'preload',
+              as: 'font',
+              type: `font/${format}`,
+              crossorigin: 'anonymous',
+              href: src
+            })
+          }
         }
       }
 
@@ -74,7 +72,9 @@ export default defineNuxtModule<ModuleOptions>({
       let typekit = false
 
       for (const font of external) {
-        if (font.src.includes('google') && !google) {
+        const { src } = font
+
+        if (src.includes('google') && !google) {
           google = true
 
           head.link?.push(
@@ -90,7 +90,7 @@ export default defineNuxtModule<ModuleOptions>({
           )
         }
 
-        if (font.src.includes('typekit') && !typekit) {
+        if (src.includes('typekit') && !typekit) {
           typekit = true
 
           head.link?.push({
@@ -104,11 +104,11 @@ export default defineNuxtModule<ModuleOptions>({
           {
             rel: 'preload',
             as: 'style',
-            href: font.src
+            href: src
           },
           {
             rel: 'stylesheet',
-            href: font.src
+            href: src
           }
         )
       }

--- a/src/runtime/composables/useExternalFont.ts
+++ b/src/runtime/composables/useExternalFont.ts
@@ -1,6 +1,6 @@
+import type { ExternalOptions } from '../../types'
 import { useHead } from '#app'
 import { generateStyles } from '../utils'
-import type { ExternalOptions } from '../../types'
 
 /**
  * Loads fonts directly from third-party servers.
@@ -26,7 +26,9 @@ export const useExternalFont = (external: ExternalOptions[]) => {
   let typekit = false
 
   for (const font of external) {
-    if (font.src.includes('google') && !google) {
+    const { src } = font
+
+    if (src.includes('google') && !google) {
       google = true
 
       links.push(
@@ -42,7 +44,7 @@ export const useExternalFont = (external: ExternalOptions[]) => {
       )
     }
 
-    if (font.src.includes('typekit') && !typekit) {
+    if (src.includes('typekit') && !typekit) {
       typekit = true
 
       links.push({
@@ -56,11 +58,11 @@ export const useExternalFont = (external: ExternalOptions[]) => {
       {
         rel: 'preload',
         as: 'style',
-        href: font.src
+        href: src
       },
       {
         rel: 'stylesheet',
-        href: font.src
+        href: src
       }
     )
   }

--- a/src/runtime/composables/useLocalFont.ts
+++ b/src/runtime/composables/useLocalFont.ts
@@ -1,6 +1,6 @@
+import type { LocalOptions } from '../../types'
 import { useHead } from '#app'
 import { generateStyles, parseFormat } from '../utils'
-import type { LocalOptions } from '../../types'
 
 /**
  * Loads fonts from the same domain as your deployment.
@@ -31,17 +31,20 @@ export const useLocalFont = (local: LocalOptions[]) => {
       preload: true,
       ...font
     }
+    const { src } = options
 
     if (options.preload) {
-      const format = parseFormat(font.src)
+      const format = parseFormat(src)
 
-      links.push({
-        rel: 'preload',
-        as: 'font',
-        type: `font/${format}`,
-        crossorigin: 'anonymous',
-        href: font.src
-      })
+      if (!links.some((v: { href?: string }) => v.href === src)) {
+        links.push({
+          rel: 'preload',
+          as: 'font',
+          type: `font/${format}`,
+          crossorigin: 'anonymous',
+          href: src
+        })
+      }
     }
   }
 

--- a/src/runtime/utils/generateStyles.ts
+++ b/src/runtime/utils/generateStyles.ts
@@ -1,5 +1,5 @@
-import { parseFormat } from './parseFormat'
 import type { LocalOptions, ExternalOptions } from '../../types'
+import { parseFormat } from './parseFormat'
 
 /**
  * Generates head styles from options entered by the user.
@@ -19,33 +19,27 @@ export const generateStyles = (fonts: LocalOptions[] | ExternalOptions[]) => {
       style: 'normal',
       ...font
     }
-    const local = options as LocalOptions
-    const srcFormat = parseFormat(options.src)
-    let format = srcFormat
-    if (srcFormat === 'ttf') format = 'truetype'
-    else if (srcFormat === 'otf') format = 'opentype'
+    const { src, family, fallback, weight, style, display } = options
+    const { class: _class, variable } = options
+    const { unicode } = options as LocalOptions
 
-    const fontFallback = options.fallback ? `,${options.fallback}` : ''
-    const fontFamily = `font-family:"${options.family}";`
-    const fontWeight = `font-weight:${options.weight};`
-    const fontDisplay = `font-display:${options.display};`
-    const fontStyle = `font-style:${options.style};`
-    const fontSrc = `src:url('${options.src}') format('${format}');`
     let unicodes = ''
-    let fontUnicode = ''
+    const format = parseFormat(src, true)
+    const fb = fallback ? `,${fallback}` : ''
 
-    if (options.class)
-      classes += `.${options.class}{font-family:"${options.family}"${fontFallback};}`
+    const faceRules = [
+      `font-family:"${family}";`,
+      `font-weight:${weight};`,
+      `font-style:${style};`,
+      `font-display:${display};`,
+      `src:url('${src}') format('${format}');`
+    ].join('')
 
-    if (options.variable)
-      variables += `--${options.variable}:"${options.family}"${fontFallback};`
+    if (unicode) unicodes = `unicode-range:${unicode};`
+    if (_class) classes += `.${_class}{font-family:"${family}"${fb};}`
+    if (variable) variables += `--${variable}:"${family}"${fb};`
 
-    if (local.unicode) {
-      for (const code of local.unicode) unicodes += `${code},`
-      fontUnicode = `unicode-range:${unicodes.replace(/,*$/, '')};`
-    }
-
-    fontFace += `@font-face{${fontFamily}${fontWeight}${fontDisplay}${fontStyle}${fontSrc}${fontUnicode}}`
+    fontFace += `@font-face{${faceRules}${unicodes}}`
   }
 
   if (variables) root += `:root{${variables}}`

--- a/src/runtime/utils/parseFormat.ts
+++ b/src/runtime/utils/parseFormat.ts
@@ -3,8 +3,13 @@
  *
  * @since 2.2.2
  */
-export const parseFormat = (src: string) => {
-  const [, format] = src.split(/\.(?=[^.]+$)/)
+export const parseFormat = (src: string, strict = false) => {
+  let [, format] = src.split(/\.(?=[^.]+$)/)
+
+  if (strict) {
+    if (format === 'ttf') format = 'truetype'
+    else if (format === 'otf') format = 'opentype'
+  }
 
   return format
 }


### PR DESCRIPTION
## Type of Change

- [x] Other 🧑‍💻

## Request Description

Cleans the code and thus reduces the final size.

## Additional Details

Also, adds a check for `preload` links when using local sources.

If there are several fonts with the same source, it adds only one `preload` link to the `<head>` section, i.e. automatically removes duplicates.
