### PR TITLE
fix: add compatibility with Nuxt 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuxt-font-loader",
-  "version": "2.3.5",
+  "version": "2.3.6",
   "description": "Simple, modern and lightweight font loader for Nuxt.",
   "author": "Ivo Dolenc",
   "license": "MIT",

--- a/src/module.ts
+++ b/src/module.ts
@@ -59,7 +59,7 @@ export default defineNuxtModule<ModuleOptions>({
         }
       }
 
-      head.style?.push({ children: styles })
+      head.style?.push(styles)
     }
 
     if (external) {
@@ -111,7 +111,7 @@ export default defineNuxtModule<ModuleOptions>({
         )
       }
 
-      if (styles) head.style?.push({ children: styles })
+      if (styles) head.style?.push(styles)
     }
   },
 })

--- a/src/runtime/composables/use-external-font.ts
+++ b/src/runtime/composables/use-external-font.ts
@@ -54,5 +54,5 @@ export const useExternalFont = (external: ExternalOptions[]) => {
 
   useHead({ link: links })
 
-  if (styles) return useHead({ style: [{ children: styles }] })
+  if (styles) return useHead({ style: [styles] })
 }

--- a/src/runtime/composables/use-local-font.ts
+++ b/src/runtime/composables/use-local-font.ts
@@ -31,5 +31,5 @@ export const useLocalFont = (local: LocalOptions[]) => {
 
   if (links.length) useHead({ link: links })
 
-  return useHead({ style: [{ children: styles }] })
+  return useHead({ style: [styles] })
 }


### PR DESCRIPTION
<!-- Thanks for opening a PR! Your contribution is much appreciated. -->

## Type of Change

<!-- Check the boxes with an 'x' that refers to your changes. -->

- [ ] Breaking change
- [ ] New feature
- [x] Bug fix
- [ ] Types
- [ ] Refactoring Code
- [ ] Tests
- [ ] Documentation
- [ ] Other

## Request Description

<!-- Describe your new request in detail. -->

Added support for `compatibilityVersion: 4` / Nuxt 4.

<!-- Add links to related issues, e.g. Fixes #number, Resolves #number, Closes #number etc. -->

## Additional Details

<!-- Provide additional information if necessary. Otherwise, feel free to skip this section. -->

When using this package with Nuxt 4 or with the `compatibilityVersion: 4` enabled, font styles are incorrectly embedded in the <head> section.


With `future: { compatibilityVersion: 4 }`:

`<style children="@font-face{font-family:&quot;Rubik&quot;;font-weight:100 200 300 400 500 600 700 800 900;font-style:normal;font-display:swap;src:url('/_static/fonts/rubik/Rubik-VariableFont_wght.woff2') format('woff2');}"></style>`

But expected:

`<style>@font-face{font-family:"Rubik";font-weight:100 200 300 400 500 600 700 800 900;font-style:normal;font-display:swap;src:url('/_static/fonts/rubik/Rubik-VariableFont_wght.woff2') format('woff2');}</style>`
